### PR TITLE
FIX 140 STATUT EVENEMENT + COMPLEMENT GESTION STATUT

### DIFF
--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -105,6 +105,27 @@ class EventController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            /* check if the format has been modified,
+               check if the number of registered players does not exceed
+               the number of players of the new format
+            */
+            if (count($event->getPlayers()) < $event->getFormatEvent()->getNumberOfPlayers()
+                && $event->getStatusEvent()->getState() == $event->getStatusEvent()->getFullState()) {
+                // change event's status to registration status
+                $statutEvent = $this->getDoctrine()->getManager()->getRepository(StatusEvent::class)
+                    ->findOneBy(['state' => $event->getStatusEvent()->getRegistrationState()], []);
+
+                $event->setStatusEvent($statutEvent);
+            }
+
+            if (count($event->getPlayers()) == $event->getFormatEvent()->getNumberOfPlayers()) {
+                // change event's status to full status
+                $statutEvent = $this->getDoctrine()->getManager()->getRepository(StatusEvent::class)
+                    ->findOneBy(['state' => $event->getStatusEvent()->getFullState()], []);
+
+                $event->setStatusEvent($statutEvent);
+            }
+
             $this->getDoctrine()->getManager()->flush();
 
             $this->addFlash(

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -3,13 +3,13 @@
 namespace App\Controller;
 
 use App\Entity\Event;
+use App\Entity\StatusEvent;
 use App\Form\EventType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use App\Repository\EventRepository;
 use App\Entity\Timer;
 use Knp\Component\Pager\PaginatorInterface;
 
@@ -18,8 +18,11 @@ class EventController extends AbstractController
 
     /**
      * @Route("manager/events", name="event_index")
+     * @param Request $request
+     * @param PaginatorInterface $paginator
+     * @return Response
      */
-    public function index(Request $request, EventRepository $eventRepository, PaginatorInterface $paginator): Response
+    public function index(Request $request, PaginatorInterface $paginator): Response
     {
         $em = $this->getDoctrine()->getmanager()->getRepository(Event::class);
         $events = $em->findBy([], ['date' => 'DESC']);
@@ -37,14 +40,19 @@ class EventController extends AbstractController
 
     /**
      * @Route("admin/event/add", name="event_add")
+     * @param Request $request
+     * @return Response
+     * @throws \Exception
      */
     public function add(Request $request): Response
     {
         $event = new Event();
 
-        $timer = $this->getDoctrine()
-            ->getRepository(Timer::class)
+        $timer = $this->getDoctrine()->getRepository(Timer::class)
             ->findOneBy([], ['id' => 'desc'], 1, 0);
+
+        $statutEvent = $this->getDoctrine()->getRepository(StatusEvent::class)
+            ->findOneBy([], [], 1, 0);
 
         $todayDate = new \DateTime();
         $logoPath = new File($this->getParameter('kernel.project_dir').'/public/images/logos/defaultLogo.png');
@@ -56,11 +64,11 @@ class EventController extends AbstractController
         $event->setLogoFile($logoPath);
         $event->setDate($todayDate);
 
-        $form = $this->createForm(
-            EventType::class,
-            $event,
-            ['method' => Request::METHOD_POST]
-        );
+        $form = $this->createForm(EventType::class, $event, [
+            'method' => Request::METHOD_POST,
+            'status' => $statutEvent->getInPreparationState(),
+            'statusFullState' => $statutEvent->getFullState(),
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -83,11 +91,15 @@ class EventController extends AbstractController
 
     /**
      * @Route("/manager/event/edit/{id}", name="event_edit", methods="GET|POST")
+     * @param Request $request
+     * @param Event $event
+     * @return Response
      */
     public function edit(Request $request, Event $event): Response
     {
         $form = $this->createForm(EventType::class, $event, [
-            'status' => $event->getStatusEvent()->getState()
+            'status' => $event->getStatusEvent()->getState(),
+            'statusFullState' => $event->getStatusEvent()->getFullState(),
         ]);
         $form->handleRequest($request);
 
@@ -110,6 +122,9 @@ class EventController extends AbstractController
 
     /**
      * @Route("/{id}", name="event_delete", methods="DELETE")
+     * @param Request $request
+     * @param Event $event
+     * @return Response
      */
     public function delete(Request $request, Event $event): Response
     {

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -100,6 +100,7 @@ class EventController extends AbstractController
         $form = $this->createForm(EventType::class, $event, [
             'status' => $event->getStatusEvent()->getState(),
             'statusFullState' => $event->getStatusEvent()->getFullState(),
+            'nbPlayers' => count($event->getPlayers())
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -9,6 +9,7 @@
 namespace App\Controller;
 
 use App\Entity\Player;
+use App\Entity\StatusEvent;
 use App\Form\PlayerType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +22,9 @@ class PlayerController extends AbstractController
 
     /**
      * @Route("/manager/player/{id}", name="player", requirements={"id"="\d+"}, methods="GET|POST")
+     * @param Request $request
+     * @param Event $event
+     * @return Response
      */
     public function addPlayer(Request $request, Event $event): Response
     {
@@ -33,6 +37,16 @@ class PlayerController extends AbstractController
             $em = $this->getDoctrine()->getManager();
             $em->persist($player);
             $em->flush();
+
+            // check if number of players max is reached
+            if (count($event->getPlayers()) === $event->getFormatEvent()->getNumberOfPlayers()) {
+                // change event's status to full status
+                $statutEvent = $em->getRepository(StatusEvent::class)
+                    ->findOneBy(['state' => $event->getStatusEvent()->getFullState()], []);
+
+                $event->setStatusEvent($statutEvent);
+                $em->flush();
+            }
 
             $this->addFlash(
                 'success',
@@ -50,17 +64,29 @@ class PlayerController extends AbstractController
     }
 
     /**
-     * @Route("/manager/player/delete/{id}", name="player_delete", requirements={"id"="\d+"}, methods="DELETE")
+     * @Route("/manager/player/{id}/delete/{player}", name="player_delete",
+     *     requirements={"id"="\d+", "player_id"="\d+"}, methods="DELETE")
+     * @param Request $request
+     * @param Event $event
+     * @param Player $player
+     * @return Response
      */
-    public function delete(Request $request, Player $player): Response
+    public function delete(Request $request, Event $event, Player $player): Response
     {
-
         if ($this->isCsrfTokenValid('delete' . $player->getId(), $request->request->get('_token'))) {
-            $event = $request->request->get('event_id');
             $em = $this->getDoctrine()->getManager();
             $em->remove($player);
             $em->flush();
 
+            // if event's status is full and the number of players is lower than number of players format
+            if (count($event->getPlayers()) < $event->getFormatEvent()->getNumberOfPlayers()) {
+                // change event's status to registration status
+                $statutEvent = $em->getRepository(StatusEvent::class)
+                    ->findOneBy(['state' => $event->getStatusEvent()->getRegistrationState()], []);
+
+                $event->setStatusEvent($statutEvent);
+                $em->flush();
+            }
 
             $this->addFlash(
                 'success',
@@ -68,6 +94,6 @@ class PlayerController extends AbstractController
             );
         }
 
-        return $this->redirectToRoute('player', ['id' => $event]);
+        return $this->redirectToRoute('player', ['id' => $event->getId()]);
     }
 }

--- a/src/Entity/StatusEvent.php
+++ b/src/Entity/StatusEvent.php
@@ -12,6 +12,17 @@ use Doctrine\ORM\Mapping as ORM;
 class StatusEvent
 {
     /**
+     * List of event's status
+     */
+    const EVENT_STATUS = [
+        [0, 'En préparation', 'secondary'],
+        [1, 'Inscription', 'info'],
+        [2, 'Complet', 'danger'],
+        [3, 'En cours', 'success'],
+        [4, 'Terminé', 'light']
+    ];
+
+    /**
      * @ORM\Id()
      * @ORM\GeneratedValue()
      * @ORM\Column(type="integer")
@@ -82,6 +93,31 @@ class StatusEvent
         $this->color = $color;
 
         return $this;
+    }
+
+    public function getInPreparationState() : int
+    {
+        return self::EVENT_STATUS[0][0];
+    }
+
+    public function getRegistrationState() : int
+    {
+        return self::EVENT_STATUS[1][0];
+    }
+
+    public function getFullState() : int
+    {
+        return self::EVENT_STATUS[2][0];
+    }
+
+    public function getInProgressState() : int
+    {
+        return self::EVENT_STATUS[3][0];
+    }
+
+    public function getFinishState() : int
+    {
+        return self::EVENT_STATUS[4][0];
     }
 
     /**

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -47,6 +47,15 @@ class EventType extends AbstractType
             ->add('formatEvent', EntityType::class, [
                 'class' => FormatEvent::class,
                 'choice_label' => 'name',
+                'choice_attr' => function ($key) use ($options) {
+                    $disabled = true;
+
+                    if ($key->getNumberOfPlayers() >= $options['nbPlayers']) {
+                        $disabled = false;
+                    }
+
+                    return $disabled ? ['disabled' => 'disabled'] : [];
+                },
                 'query_builder' => function (EntityRepository $er) {
                     return $er->createQueryBuilder('f')
                         ->orderBy('f.numberOfPlayers', 'ASC');

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -31,7 +31,7 @@ class EventType extends AbstractType
                     $disabled = true;
 
                     if ($key->getState() == $options['status'] || ($options['status'] < $options['statusFullState']
-                            && $key->getState() < $options['statusFullState'])) {
+                            && $key->getState() < $options['statusFullState'] && $options['nbPlayers'] == 0)) {
                         $disabled = false;
                     }
 
@@ -82,6 +82,7 @@ class EventType extends AbstractType
             'data_class' => Event::class,
             'status' => null,
             'statusFullState' => null,
+            'nbPlayers' => 0
         ]);
     }
 }

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -30,7 +30,8 @@ class EventType extends AbstractType
                 'choice_attr' => function ($key) use ($options) {
                     $disabled = true;
 
-                    if ($key->getState() == $options['status'] || ($options['status'] < 2 && $key->getState() < 2)) {
+                    if ($key->getState() == $options['status'] || ($options['status'] < $options['statusFullState']
+                            && $key->getState() < $options['statusFullState'])) {
                         $disabled = false;
                     }
 
@@ -79,7 +80,8 @@ class EventType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Event::class,
-            'status' => 0,
+            'status' => null,
+            'statusFullState' => null,
         ]);
     }
 }

--- a/templates/event/edit.html.twig
+++ b/templates/event/edit.html.twig
@@ -13,7 +13,10 @@
         <hr>
             {{ form_row(formEdit.statusEvent, {'label': 'Statut de l\'événement'}) }}
             {% set sentence = '' %}
-            {% if event.statusEvent.state == event.statusEvent.fullState %}
+            {% if event.statusEvent.state == event.statusEvent.registrationState and event.players|length > 0 %}
+                {% set sentence = 'Des participants sont inscrits à l\'événement.
+                                   Pour remettre le statut "En préparation", veuillez les supprimer.' %}
+            {% elseif event.statusEvent.state == event.statusEvent.fullState %}
                 {% set sentence = 'L\'événement est complet. Si vous souhaitez plus de participants, contactez l\'administrateur.' %}
             {% elseif  event.statusEvent.state == event.statusEvent.inProgressState %}
                 {% set sentence = 'L\'événement est en cours, il ne peut être modifié.' %}
@@ -24,7 +27,7 @@
             {% if sentence is not empty %}
                 <p>
                     <span class="badge badge-{{ event.statusEvent.color }}">{{ event.statusEvent.name }}</span>
-                    <span class="text-danger">{{ sentence }}</span>
+                    <span class="text-{{ event.statusEvent.color }}">{{ sentence }}</span>
                 </p>
             {% endif %}
         <hr>

--- a/templates/event/edit.html.twig
+++ b/templates/event/edit.html.twig
@@ -36,6 +36,9 @@
         <div class="row">
             <div class="col-lg-6">
                 {{ form_row(formEdit.formatEvent, {'label': 'Format de l\'événement'}) }}
+                <p class="mb-0 text-secondary">
+                    <i>Nombre d'inscrits : {{ event.players|length ~ ' / '~ event.formatEvent.numberOfPlayers }}</i>
+                </p>
             </div>
             <div class="col-lg-6">
                 {{ form_row(formEdit.logoFile, {'label': 'Modification du logo'}) }}

--- a/templates/event/edit.html.twig
+++ b/templates/event/edit.html.twig
@@ -13,11 +13,11 @@
         <hr>
             {{ form_row(formEdit.statusEvent, {'label': 'Statut de l\'événement'}) }}
             {% set sentence = '' %}
-            {% if event.statusEvent.state == 2 %}
+            {% if event.statusEvent.state == event.statusEvent.fullState %}
                 {% set sentence = 'L\'événement est complet. Si vous souhaitez plus de participants, contactez l\'administrateur.' %}
-            {% elseif  event.statusEvent.state == 3 %}
+            {% elseif  event.statusEvent.state == event.statusEvent.inProgressState %}
                 {% set sentence = 'L\'événement est en cours, il ne peut être modifié.' %}
-            {% elseif  event.statusEvent.state == 4  %}
+            {% elseif  event.statusEvent.state == event.statusEvent.finishState  %}
                 {% set sentence = 'L\'événement est terminé, il ne peut être modifié.' %}
             {% endif %}
 

--- a/templates/event/index.html.twig
+++ b/templates/event/index.html.twig
@@ -22,13 +22,13 @@
                 </div>
 
                 <div class="col-md-1 col-2 text-md-right">
-                    {% if event.statusEvent.state < 3 %}
+                    {% if event.statusEvent.state < event.statusEvent.inProgressState %}
                         <a href="{{ path('event_edit', {'id': event.id }) }}"><i class="fas fa-edit"></i></a>
                     {% endif %}
                 </div>
 
                 <div class="col-md-1 col-2">
-                    {% if event.statusEvent.state != 3 %}
+                    {% if event.statusEvent.state != event.statusEvent.inProgressState %}
                         <form method="post" action="{{ path('event_delete', {'id': event.id}) }}"
                               onsubmit="return confirm('Voulez-vous vraiment supprimer cet événement ?');">
                             <input type="hidden" name="_method" value="DELETE">

--- a/templates/event/index.html.twig
+++ b/templates/event/index.html.twig
@@ -18,7 +18,9 @@
                     <span class="badge badge-{{ event.statusEvent.color }}">{{ event.statusEvent.name }}</span>
                 </div>
                 <div class="col-md-1 col-2 text-md-right">
-                    <a href="{{ path('player', {'id': event.id}) }}"><i class="fas fa-user"></i></a>
+                    {% if event.statusEvent.state != event.statusEvent.inPreparationState %}
+                        <a href="{{ path('player', {'id': event.id}) }}"><i class="fas fa-user"></i></a>
+                    {% endif %}
                 </div>
 
                 <div class="col-md-1 col-2 text-md-right">

--- a/templates/player/index.html.twig
+++ b/templates/player/index.html.twig
@@ -6,24 +6,30 @@
 
     <div class="event_players container">
         <h1 class="text-center">Gestion des participants</h1>
-        <h2 class="text-center pt-1">{{ event.date|date('d M Y') }}
+        <h2 class="text-center pt-1">{{ event.title }}</h2>
         <hr />
-        {{ event.title }}</h2>
-        <p class="pt-2"><strong><u>Gestion participants</u></strong></p>
-        <p>
-            <div class="row">
-                <div class="col">
-                    <a class="btn btn-primary" data-toggle="collapse" href="#collapsePlayerForm" role="button" aria-expanded="false" aria-controls="collapsePlayerForm  ">
+        <h2 class="text-center pt-1">{{ event.date|date('d M Y') }}</h2>
+        <div class="row">
+            <div class="col-6">
+                <p class="pt-2">
+                    <strong><u>Participants</u></strong>
+                    - Nombre d'inscrits {{ event.players|length ~ ' / '~ event.formatEvent.numberOfPlayers }}
+                    - <span class="badge badge-{{ event.statusEvent.color }}">{{ event.statusEvent.name }}</span>
+                </p>
+                {% if (event.statusEvent.state < event.statusEvent.fullState) %}
+                    <a class="btn btn-primary align-self-end" data-toggle="collapse" href="#collapsePlayerForm"
+                       role="button" aria-expanded="false" aria-controls="collapsePlayerForm  ">
                         <i class="fas fa-user-plus"></i> Ajouter un participant
                     </a>
-                </div>
-                <div class="col justify-content-end text-right">
-                    <a class="btn btn-primary" data-toggle="collapse" href="" role="button" aria-expanded="false">
-                        <i class="fas fa-play"></i> Lancer l'événement
-                    </a>
-                </div>
+                {% endif %}
             </div>
-        </p>
+            <div class="col-6 align-self-end text-right">
+                <a class="btn btn-primary" data-toggle="collapse" href="" role="button" aria-expanded="false">
+                    <i class="fas fa-play"></i> Lancer l'événement
+                </a>
+            </div>
+        </div>
+
         <div class="collapse" id="collapsePlayerForm">
             {{ include('player/_formPlayer.html.twig') }}
             <hr/>
@@ -47,10 +53,9 @@
                      <a href=""><i class="fas fa-edit"></i></a>
             </div>
              <div class="col-sm-1 col-xs-12">
-                 <form method="post" action="{{ path('player_delete', {'id': player.id}) }}"
+                 <form method="post" action="{{ path('player_delete', {'id': event.id, 'player': player.id}) }}"
                        onsubmit="return confirm('Etes vous sûr de vouloir supprimer ce participant ?');">
                      <input type="hidden" name="_method" value="DELETE">
-                     <input type="hidden" name="event_id" value="{{ event.id }}">
                      <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ player.id) }}">
                      <button class="listButton btn"><i class="fas fa-times"></i></button>
                  </form>


### PR DESCRIPTION
-  Ajout de getters et retrait des valeurs en dur
- Gestion du statut en fonction du nombre d'inscrits (statut complet + masquer bouton ajouter, revenir au statut inscription si un participant est supprimé)
- Impossibilité de revenir à l'état En préparation, si il y a des inscrits
- Gestion du statut en fonction du format de l'événement, si evenement complet mais upgrade du format -> statut = inscritpion, si evenement incomplet  pas possible de diminuer format si nombre de personnes déjà inscrites supérieur au nombre de personnes du nouveau format sélectionné
